### PR TITLE
Fixed Issue #3

### DIFF
--- a/scrapper/src/controllers/profileController.js
+++ b/scrapper/src/controllers/profileController.js
@@ -22,7 +22,7 @@ const getSingleProfile = async (req, res, next) => {
         let profile = null;
 
         // Find profile document by it's userHandle / publicIdentifier from database
-        let profileDoc = await ProfileModel.findOne({ publicIdentifier: userHandle });
+        let profileDoc = await ProfileModel.findOne({ publicIdentifier: profileIdentifier });
 
         // Check If we got a valid document or null / undefined 
         if (profileDoc) {


### PR DESCRIPTION
This pull request addresses a bug in the code that occurs when sending a POST request to the "/api/profile" endpoint with a URL in the request body instead of a user handle. The issue was causing the userHandle variable to become undefined when a URL was used, resulting in unexpected behavior.

To resolve this issue, the following changes were made in the code:

1. When the request body contains a URL, the `profileIdentifier` variable is set to the result of the `getUserHandle(url)` function, which ensures that the user handle is correctly identified from the URL.

2. Previously, the code was querying the `ProfileModel` collection using the `publicIdentifier` field with the `userHandle` variable. This resulted in issues when a URL was used, as the `userHandle` variable was undefined. To fix this, the code was updated to query the `ProfileModel` collection using the `profileIdentifier` variable, which is correctly set based on the request content.

By making this change, the bug is resolved, and the code now functions correctly when either a user handle or a URL is provided in the request body. This ensures that the `ProfileModel` query is performed using the correct identifier, improving the overall reliability of the `/api/profile` endpoint.